### PR TITLE
MNT: Updated some of the pinned versions

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - python
     - setuptools
     - blas 1.1 {{ variant }}
-    - openblas 0.2.20|0.2.20.*
+    - openblas 0.2.19|0.2.19.*
     - gsl
     - fftw
     - glpk
@@ -32,7 +32,7 @@ requirements:
   run:
     - python
     - blas 1.1 {{ variant }}
-    - openblas 0.2.20|0.2.20.*
+    - openblas 0.2.19|0.2.19.*
     - gsl
     - fftw
     - glpk

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 200
+  number: 201
   features:
     - blas_{{ variant }}
 
@@ -23,20 +23,20 @@ requirements:
     - python
     - setuptools
     - blas 1.1 {{ variant }}
-    - openblas 0.2.19|0.2.19.*
+    - openblas 0.2.20|0.2.20.*
     - gsl
     - fftw
     - glpk
-    - suitesparse 4.5.*
+    - suitesparse 4.5.4
 
   run:
     - python
     - blas 1.1 {{ variant }}
-    - openblas 0.2.19|0.2.19.*
+    - openblas 0.2.20|0.2.20.*
     - gsl
     - fftw
     - glpk
-    - suitesparse 4.5.*
+    - suitesparse 4.5.4
 
 test:
   imports:


### PR DESCRIPTION
Pin suitesparse at patch-level to avoid install_name issue:
conda-forge/suitesparse-feedstock#22